### PR TITLE
”async/await” more aggressive. + more

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mpd"
   ],
   "devDependencies": {
-    "eslint": "^5.11.1",
+    "eslint": "^7.18.0",
     "jest": "^26.6.3"
   },
   "author": "Roman Burunkov <romon2002@gmail.com>",

--- a/src/mpd.js
+++ b/src/mpd.js
@@ -105,23 +105,6 @@ module.exports = class MPD extends EventEmitter {
     return await this.command(...args);
   }
 
-  async currentSong() {
-    const r = await this._sendCommand('currentsong');
-    const arr = r.split('\n');
-    const res_status = arr.pop();
-    await this._answerCallbackError(res_status);
-    const data = {};
-    try {
-      for (const line of arr) {
-        const kvp = parseKvp(line);
-        data[kvp.key] = kvp.val;
-      }
-    } catch (e) {
-      throw new Error(`Unknown response while fetching currentsong: ${e}`);
-    }
-    return data;
-  }
-
   /**
    * Connect and disconnect
    */

--- a/src/mpd.js
+++ b/src/mpd.js
@@ -105,6 +105,23 @@ module.exports = class MPD extends EventEmitter {
     return await this.command(...args);
   }
 
+  async currentSong() {
+    const r = await this._sendCommand('currentsong');
+    const arr = r.split('\n');
+    const res_status = arr.pop();
+    await this._answerCallbackError(res_status);
+    const data = {};
+    try {
+      for (const line of arr) {
+        const kvp = parseKvp(line);
+        data[kvp.key] = kvp.val;
+      }
+    } catch (e) {
+      throw new Error(`Unknown response while fetching currentsong: ${e}`);
+    }
+    return data;
+  }
+
   /**
    * Connect and disconnect
    */

--- a/src/mpd.js
+++ b/src/mpd.js
@@ -70,7 +70,7 @@ module.exports = class MPD extends EventEmitter {
         data[kvp.key] = kvp.val;
       }
     } catch (e) {
-      throw new Error(`An error occurred while parsing the query response. %o, $o`, arguments, e);
+      throw new Error(`An error occurred while parsing the query response. ${e}`);
     }
     return data;
   }

--- a/src/mpd.js
+++ b/src/mpd.js
@@ -58,6 +58,23 @@ module.exports = class MPD extends EventEmitter {
     return await this._answerCallbackError(r);
   }
 
+  async query() {
+    const r = await this._sendCommand(...arguments);
+    const arr = r.split('\n');
+    const res_status = arr.pop();
+    await this._answerCallbackError(res_status);
+    const data = {};
+    try {
+      for (const line of arr) {
+        const kvp = parseKvp(line);
+        data[kvp.key] = kvp.val;
+      }
+    } catch (e) {
+      throw new Error(`An error occurred while parsing the query response. %o, $o`, arguments, e);
+    }
+    return data;
+  }
+
   alive() {
     return this.connected;
   }
@@ -103,23 +120,6 @@ module.exports = class MPD extends EventEmitter {
       args.push(search[key]);
     }
     return await this.command(...args);
-  }
-
-  async currentSong() {
-    const r = await this._sendCommand('currentsong');
-    const arr = r.split('\n');
-    const res_status = arr.pop();
-    await this._answerCallbackError(res_status);
-    const data = {};
-    try {
-      for (const line of arr) {
-        const kvp = parseKvp(line);
-        data[kvp.key] = kvp.val;
-      }
-    } catch (e) {
-      throw new Error(`Unknown response while fetching currentsong: ${e}`);
-    }
-    return data;
   }
 
   /**

--- a/src/mpd.js
+++ b/src/mpd.js
@@ -336,13 +336,13 @@ module.exports = class MPD extends EventEmitter {
       this.commanding = true;
       // It is possible to get a change event or just OK message
       if (message.match(/^\s*OK/)) return;
-      const matches = [...message.matchAll(/changed:\s*(.*)/g)];
+      const matches = [...message.match(/(?:changed:\s*)(.*)/g)];
       if (!matches.length) {
         this.restoreConnection();
         throw new Error(`Received unknown message during idle: ${message}`);
       }
       for (const match of matches) {
-        const update = match[1];
+        const update = match.substring(9);
         const afterUpdate = () => {
           this.emit('update', update);
           this.emit('status', update);

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -7,11 +7,14 @@
  * @returns {Object|false} KVP object of false if parsing failed.
  */
 module.exports.parseKvp = (kvp = '') => {
-  if (!kvp) return false;
-  const m = kvp.match(/(\S+)\s*:\s*(\S+)/);
-  return Array.isArray(m) && m.length === 3
-    ? { key: m[1].trim(), val: m[2].trim() }
-    : false;
+  if (!kvp) {
+    throw new Error('found void data in parseKvp');
+  }
+  const m = kvp.replace(/\s+/g, ' ').match(/(\S+) ?: ?(.+)$/);
+  if (Array.isArray(m) && m.length === 3) {
+    return { key: m[1].trim(), val: m[2].trim() };
+  }
+  throw new Error('occurred invalid string in parseKvp');
 };
 
 /**
@@ -24,7 +27,8 @@ module.exports.parseKvp = (kvp = '') => {
  */
 module.exports.parseGreeting = (message = '') => {
   const m = message.match(/OK\s(.+)\s(.+)/);
-  return Array.isArray(m) && m.length === 3
-    ? { name: m[1], version: m[2] }
-    : false;
+  if (Array.isArray(m) && m.length === 3) {
+    return { name: m[1], version: m[2] };
+  }
+  throw new Error('occurred invalid string in parseGreeting');
 };

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -2,12 +2,13 @@ const proto = require('../src/protocol');
 
 describe('Test parseKvp function', () => {
   test('Is defined', () => expect(proto.parseKvp).toBeDefined());
-  test('Returns false if no data passed', () => expect(proto.parseKvp()).toBe(false));
-  test('Returns false if passed string doesnt match kvp format', () => {
-    expect(proto.parseKvp('no kvp')).toBe(false);
+  test('Throw error if no data passed', () => expect(() => {proto.parseKvp()}).toThrow('found void data in parseKvp'));
+  test('Throw error if passed string doesnt match kvp format', () => {
+    expect(() => {proto.parseKvp('no kvp')}).toThrow('occurred invalid string in parseKvp');
   });
-  test('Doesnt returns false if passed string matches kvp format', () => {
-    expect(proto.parseKvp('vol: 42')).toBeTruthy();
+  test('Returned Object if passed string matches kvp format', () => {
+    expect(typeof proto.parseKvp('vol: 42')).toBe('object');
+    expect(typeof proto.parseKvp('vol: 42')).not.toBeNull();
   });
   test('Returned value has key prop if passed string matches kvp format', () => {
     const kvp = proto.parseKvp('vol: 42');
@@ -25,13 +26,15 @@ describe('Test parseKvp function', () => {
 });
 
 describe('Test parseGreeting function', () => {
+  const error_message = 'occurred invalid string in parseGreeting';
   test('Is defined', () => expect(proto.parseGreeting).toBeDefined());
-  test('Returns false if no data passed', () => expect(proto.parseGreeting()).toBe(false));
-  test('Returns false if passed string doesnt match greetings format', () => {
-    expect(proto.parseGreeting('Failed greetings')).toBe(false);
+  test('Throw error if no data passed', () => expect(() => {proto.parseGreeting()}).toThrow(error_message));
+  test('Throw error if passed string doesnt match greetings format', () => {
+    expect(() => {proto.parseGreeting('Failed greetings')}).toThrow(error_message);
   });
-  test('Doesnt returns false if passed string matches greetings format', () => {
-    expect(proto.parseGreeting('OK MPD 0.20.2')).toBeTruthy();
+  test('Returned Object if passed string matches greetings format', () => {
+    expect(typeof proto.parseGreeting('OK MPD 0.20.2')).toBe('object');
+    expect(typeof proto.parseGreeting('OK MPD 0.20.2')).not.toBeNull();
   });
   test('Returned value has name prop if passed string matches greetings format', () => {
     const greeting = proto.parseGreeting('OK MPD 0.20.2');


### PR DESCRIPTION
Hello.

PullRequest the fix I made.
If you like it, merge it.

- Changed to use async / await more aggressively.
- TypeError occurred in matchAll (), so I modified the relevant part.
- Fix broken string during parse song if contain white space.
- Throw error if invalid params in parseKvp or parseGreeting. (for type consistency)
- feauture: new procedure 'query'

Thank you for the wonderful product.